### PR TITLE
APE-9649 release version change from 0.1.1 to 0.1.2 for plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents notable changes to the terrascan-rego-editor.
 
+## [v0.1.2]
+### Bugfix
+- Fixed a bug causing failure while invoking tenable cs apis.
+
 ## [v0.1.1]
 ### Bugfix
 - Fixed a bug causing failure while installing for the first time users.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "terrascan-rego-editor",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "terrascan-rego-editor",
-			"version": "0.1.1",
+			"version": "0.1.2",
 			"dependencies": {
 				"decompress": "^4.2.1",
 				"strip-ansi": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "terrascan-rego-editor",
 	"displayName": "Terrascan Rego Editor",
 	"description": "Develop custom policies for Terrascan",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"publisher": "AccuricsInc",
 	"icon": "assets/terrascan-rego-editor.png",
 	"repository": {


### PR DESCRIPTION
Incrementing minor version of plugin. Fixed APE-9649 unable to invoke tenable cs apis. Respective change was in siac service released with 2.5.7 prod push.